### PR TITLE
Fix gem file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,12 +68,6 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-
-gem "aws-sdk-s3" 
-gem "devise", "~> 4.5"
-
-gem "pundit", "~> 2.0"
-
 gem 'stripe', '~> 3.29'
 
 gem 'active_storage_drag_and_drop'


### PR DESCRIPTION
got the following message while bundling, so i deleted the duplicated gems

Your Gemfile lists the gem aws-sdk-s3 (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of one of them later.
Your Gemfile lists the gem devise (~> 4.5) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of one of them later.
Your Gemfile lists the gem pundit (~> 2.0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of one of them later.